### PR TITLE
You have to cast to int on keepalive sequence

### DIFF
--- a/src/Subject/WebSocketSubject.php
+++ b/src/Subject/WebSocketSubject.php
@@ -66,7 +66,7 @@ final class WebSocketSubject extends Subject
                     $pingTimer = $this->loop->addPeriodicTimer(30, function (Timer $timer) use (&$lastReceivedPong) {
                         static $sequence = 0;
 
-                        if ($lastReceivedPong !== $sequence) {
+                        if ((int)$lastReceivedPong !== $sequence) {
                             $timer->cancel();
                             if ($this->socket) {
                                 $this->socket->close();


### PR DESCRIPTION
The client disconnects regularly because it is trying to compare a string to an int here.